### PR TITLE
remove blank line after curly bracket opening

### DIFF
--- a/test/GihanSoft.ExtensionMethods.Test.CsCore/System.String.cs
+++ b/test/GihanSoft.ExtensionMethods.Test.CsCore/System.String.cs
@@ -5,8 +5,8 @@ using System.Text;
 using Xunit;
 
 namespace GihanSoft.ExtensionMethods.Test.CsCore {
-    public class System {
-
+    public class System 
+    {
         [Fact]
         public void DecodeDefault () {
             var str = "یک رشته‌ی تصادفی";


### PR DESCRIPTION
To improve the readability of the code, StyleCop requires blank lines in certain situations, and prohibits blank lines in other situations. This results in a consistent visual pattern across the code, which can improve recognition and readability of unfamiliar code.